### PR TITLE
release 1.3.1

### DIFF
--- a/WONDER-CHANGELOG.md
+++ b/WONDER-CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change Log In Wonder
 
+### 1.3.1 (09/08/2022)
+* log-processor: change action index name separation from app level to group level.
+* log-processor: add `app.log.group.mapping` property to load action log group mapping.
+* action log context: add info support. use ActionLogContext.info() to add info value.
+
 ### 1.3.0 (08/19/2022)
 * corresponds to upstream version **7.10.6**
 * bean validator: remove calling of BeanClassNameValidator, since we can’t coordinate all teams prevent them to use the same class name

--- a/publish.json
+++ b/publish.json
@@ -3,47 +3,47 @@
     {
       "name": "core-ng",
       "artifactId": "core-ng",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-api",
       "artifactId": "core-ng-api",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-json",
       "artifactId": "core-ng-json",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-common",
       "artifactId": "core-ng-common",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-mongo",
       "artifactId": "core-ng-mongo",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-mongo-test",
       "artifactId": "core-ng-mongo-test",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-search",
       "artifactId": "core-ng-search",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-search-test",
       "artifactId": "core-ng-search-test",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "core-ng-test",
       "artifactId": "core-ng-test",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }


### PR DESCRIPTION
* log-processor: change action index name separation from app level to group level.
* log-processor: add `app.log.group.mapping` property to load action log group mapping.
* action log context: add info support. use ActionLogContext.info() to add info value.